### PR TITLE
Remove duplicate includePaths property passed to sass

### DIFF
--- a/Gulpfile.js
+++ b/Gulpfile.js
@@ -28,8 +28,7 @@ gulp.task("browserSync", function() {
 gulp.task("sass", function() {
 	gulp.src("src/scss/**/*.scss")
 			.pipe(sass({
-				includePaths: bourbon,
-				includePaths: neat
+				includePaths: bourbon.concat(neat)
 			}))
 			.pipe(gulp.dest("dist/css"))
 			.pipe(browserSync.reload({


### PR DESCRIPTION
• Object passed to sass on line 30 had two `includePaths` properties
• Removed duplicate property and combined `bourbon` and `neat` into single array as new value of `includePaths` property